### PR TITLE
DHEK14 - Remove unique name constraint

### DIFF
--- a/Dhek/Property.hs
+++ b/Dhek/Property.hs
@@ -21,10 +21,6 @@ onProp = compile $ do
   where
     go (r,n,t) = do
         rs <- getRects
-        let msg = "\"" ++ n ++ "\" is already used"
-            r1  = r & rectName .~ n
+        let r1  = r & rectName .~ n
                     & rectType .~ t
-            pred o = (o ^. rectName) == n && (o ^. rectId) /= (r ^. rectId)
-            exists = any pred rs
-        when exists (showError msg)
-        when (not exists) (setSelected (Just r1))
+        setSelected (Just r1)


### PR DESCRIPTION
I was wrong with that:
- It doest' comply with some area type like `radio`.
- It prevent displaying same value in several area (referencing the same name, e.g. repeat first/last name accross pages).
