### PR TITLE
Resources layout

### DIFF
--- a/Dhek/GUI.hs
+++ b/Dhek/GUI.hs
@@ -13,7 +13,10 @@ import Data.Foldable (traverse_)
 --------------------------------------------------------------------------------
 import           Control.Lens ((^.))
 import qualified Graphics.UI.Gtk as Gtk
-import           System.FilePath (joinPath)
+import           System.FilePath (joinPath, dropFileName)
+import           System.Environment.Executable (getExecutablePath)
+
+import Debug.Trace (trace)
 
 --------------------------------------------------------------------------------
 import Dhek.I18N
@@ -93,6 +96,10 @@ makeGUI = do
               Gtk.FileChooserActionOpen
               msgStr
 
+    -- Runtime directories
+    execPath <- getExecutablePath
+    let resDir = joinPath [dropFileName execPath, "resources"]
+
     -- Menu Bar
     mbar   <- Gtk.menuBarNew
     fmenu  <- Gtk.menuNew
@@ -116,33 +123,33 @@ makeGUI = do
 
     -- Button Next
     next <- Gtk.buttonNew
-    nimg <- Gtk.imageNewFromFile $ joinPath ["resources", "page-next.png"]
+    nimg <- Gtk.imageNewFromFile $ joinPath [resDir, "page-next.png"]
     Gtk.buttonSetImage next nimg
 
      -- Previous Prev
     prev <- Gtk.buttonNew
-    pimg <- Gtk.imageNewFromFile $ joinPath ["resources", "page-previous.png"]
+    pimg <- Gtk.imageNewFromFile $ joinPath [resDir, "page-previous.png"]
     Gtk.buttonSetImage prev pimg
 
     -- Button Zoom out
     minus <- Gtk.buttonNew
-    oimg  <- Gtk.imageNewFromFile $ joinPath ["resources", "zoom-out.png"]
+    oimg  <- Gtk.imageNewFromFile $ joinPath [resDir, "zoom-out.png"]
     Gtk.buttonSetImage minus oimg
 
     -- Button Zoom in
     plus <- Gtk.buttonNew
-    iimg <- Gtk.imageNewFromFile $ joinPath ["resources", "zoom-in.png"]
+    iimg <- Gtk.imageNewFromFile $ joinPath [resDir, "zoom-in.png"]
     Gtk.buttonSetImage plus iimg
 
     -- Button Draw
     drwb <- Gtk.toggleButtonNew
-    dimg <- Gtk.imageNewFromFile $ joinPath ["resources", "draw.png"]
+    dimg <- Gtk.imageNewFromFile $ joinPath [resDir, "draw.png"]
     Gtk.buttonSetImage drwb dimg
     Gtk.toggleButtonSetActive drwb True
 
     -- Button MultiSelection
     msb  <- Gtk.toggleButtonNew
-    simg <- Gtk.imageNewFromFile $ joinPath ["resources", "multisel.png"]
+    simg <- Gtk.imageNewFromFile $ joinPath [resDir, "multisel.png"]
     Gtk.buttonSetImage msb simg
 
     -- Toolbar
@@ -201,6 +208,7 @@ makeGUI = do
     atswin <- Gtk.alignmentNew 0 0 1 1
     col    <- Gtk.treeViewColumnNew
     trend  <- Gtk.cellRendererTextNew
+
     let mapping r = [Gtk.cellText Gtk.:= r ^. rectName]
     Gtk.treeViewColumnSetTitle col $ msgStr $ MsgAreas
     Gtk.cellLayoutPackStart col trend False

--- a/dhek.cabal
+++ b/dhek.cabal
@@ -36,6 +36,7 @@ executable dhek
                        , mtl         >= 2.1.2
                        , cairo       >= 0.12.4
                        , filepath    >= 1.3.0    && < 1.3.1
+                       , executable-path == 0.0.3
                        , aeson       == 0.7.*
                        , bytestring  >= 0.9.2.1  && < 0.11
                        , containers  >= 0.4.0    && < 0.6

--- a/util/macosx-mkapp.sh
+++ b/util/macosx-mkapp.sh
@@ -12,6 +12,7 @@ mkdir -p "$BUILDDIR/$APPNAME.app/Contents/MacOS/lib"
 mkdir -p "$BUILDDIR/$APPNAME.app/Contents/Resources"
  
 cp "$BINPATH" "$BUILDDIR/$APPNAME.app/Contents/MacOS/"
+cp -R `dirname $0`/../resources "$BUILDDIR/$APPNAME.app/Contents/MacOS/resources"
  
 echo "Will process dependencies ..."
 DEPS=`otool -L "$BUILDDIR/$APPNAME.app/Contents/MacOS/$BINFILE" | grep '.dylib' | grep -v '@' | grep -v '/usr/lib' | awk '{ printf("%s\n", $1); }'`

--- a/util/win-msys2-dist.sh
+++ b/util/win-msys2-dist.sh
@@ -9,7 +9,7 @@ mkdir -p "$DISTDIR/bin"
 
 cp dist/build/dhek/dhek.exe "$DISTDIR/bin/"
 cp util/win-dlls/*.dll "$DISTDIR/bin/"
-cp -R resources "$DISTDIR/resources"
+cp -R resources "$DISTDIR/bin/resources"
 
 cat > "$DISTDIR/dhek.bat" << EOF
 start bin\dhek.exe


### PR DESCRIPTION
Locate `resources` directory starting from path to executable (`dhek` or `dhek.exe`) so that is works without a `.bat` launcher on Windows, and simply work on Mac OS X.
