### PR TITLE
Integration with Cocoa Loop

### DIFF
--- a/Dhek/DarwinUtil.hs
+++ b/Dhek/DarwinUtil.hs
@@ -1,0 +1,15 @@
+{-# INCLUDE "../darwin/util.h" #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+--------------------------------------------------------------------------------
+-- |
+-- Module : Dhek.DarwinUtil
+--
+-- This module declares everything related to the GUI like widgets
+--
+--------------------------------------------------------------------------------
+module Dhek.DarwinUtil where
+
+import Foreign.C
+
+foreign import ccall "nsappTerminate" nsappTerminate :: IO ()

--- a/Dhek/GUI.chs
+++ b/Dhek/GUI.chs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 --------------------------------------------------------------------------------
 -- |
 -- Module : Dhek.GUI
@@ -19,6 +21,10 @@ import           System.Environment.Executable (getExecutablePath)
 --------------------------------------------------------------------------------
 import Dhek.I18N
 import Dhek.Types
+
+#if defined __APPLE__
+import Dhek.Darwin
+#endif
 
 --------------------------------------------------------------------------------
 data GUI =
@@ -294,7 +300,13 @@ makeGUI = do
                 , Gtk.containerBorderWidth Gtk.:= 10
                 ]
 
-    Gtk.onDestroy win Gtk.mainQuit
+    Gtk.onDestroy win $ do
+                Gtk.mainQuit
+#if defined __APPLE__
+                nsappTerminate
+#endif
+
+
     Gtk.widgetShowAll win
 
     return $ GUI{ guiWindow = win

--- a/darwin/AppDelegate.m
+++ b/darwin/AppDelegate.m
@@ -9,10 +9,30 @@
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
+  [self performSelectorOnMainThread:@selector(setUp) 
+                         withObject:nil waitUntilDone:NO];
+}
+
+/*
+  Wraps GTK/UI launch so that it can be runned in main NS run loop,
+  not to block AppKit/UI thread.
+*/
+- (void)setUp
+{
   launch();
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification
+{
+  [self performSelectorOnMainThread:@selector(tearDown) 
+                         withObject:nil waitUntilDone:NO];
+}
+
+/*
+  Wraps Haskell release so that it can be done in main NS run loop,
+  not to block AppKit/UI thread.
+*/
+- (void)tearDown
 {
   hs_exit();
 }

--- a/darwin/dhek/Darwin.hs
+++ b/darwin/dhek/Darwin.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+--------------------------------------------------------------------------------
+-- |
+-- Module : Dhek.Darwin
+--
+-- This module declares utilities related to Darwin/Mac OS X integration.
+--
+--------------------------------------------------------------------------------
+module Dhek.Darwin where
+
+import Foreign.C
+
+foreign import ccall "util.h nsappTerminate" nsappTerminate :: IO ()

--- a/darwin/util.h
+++ b/darwin/util.h
@@ -1,0 +1,1 @@
+void nsappTerminate();

--- a/darwin/util.m
+++ b/darwin/util.m
@@ -1,0 +1,10 @@
+#include <Cocoa/Cocoa.h>
+#include "util.h"
+
+/** Wraps ObjC call to be used as foreign function. */
+void nsappTerminate() {
+  [NSApp terminate: nil];
+}
+
+extern void nsappTerminate();
+

--- a/dhek.cabal
+++ b/dhek.cabal
@@ -33,7 +33,9 @@ executable dhek
                  Dhek.Types
 
   if os(darwin)
-    c-sources: darwin/AppDelegate.m
+    c-sources: darwin/AppDelegate.m darwin/util.m
+    hs-source-dirs: . darwin
+    other-modules: Dhek.Darwin
     main-is: darwin/main.m
   else
     main-is: Main.hs


### PR DESCRIPTION
Considering Mac OS X/Cocoa threading model, take care not to directly perform application features from the custom application delegate (`AppDelegate`), but request it (with wrappers `launch` and `tearDown`) to be run asynchronously by Cocoa main loop.
