### PR TITLE
DHEK28 - Property 'index' for textcell area

### DIFF
--- a/Dhek/GUI.hs
+++ b/Dhek/GUI.hs
@@ -58,6 +58,8 @@ data GUI =
     , guiModeToolbar :: Gtk.HButtonBox
     , guiTranslate :: DhekMessage -> String
     , guiDokButton :: Gtk.Button
+    , guiIndexAlign :: Gtk.Alignment
+    , guiIndexSpin :: Gtk.SpinButton
     }
 
 --------------------------------------------------------------------------------
@@ -247,17 +249,20 @@ makeGUI = do
     -- Properties
     rem     <- Gtk.buttonNewWithLabel $ msgStr MsgRemove
     app     <- Gtk.buttonNewWithLabel $ msgStr MsgApply
+    idxspin <- Gtk.spinButtonNewWithRange 0 200 1
     nlabel  <- Gtk.labelNew (Just $ msgStr MsgName)
     tlabel  <- Gtk.labelNew (Just $ msgStr MsgType)
     vlabel  <- Gtk.labelNew (Just $ msgStr MsgValue)
+    idxlabel <- Gtk.labelNew (Just $ msgStr MsgIndex)
     pentry  <- Gtk.entryNew
     ventry  <- Gtk.entryNew
     ualign  <- Gtk.alignmentNew 0.5 0 0 0
     nalign  <- Gtk.alignmentNew 0 0.5 0 0
     talign  <- Gtk.alignmentNew 0 0.5 0 0
     valign  <- Gtk.alignmentNew 0 0.5 0 0
+    idxalign <- Gtk.alignmentNew 0 0.5 0 0
     salign  <- Gtk.alignmentNew 0 0 1 0
-    table   <- Gtk.tableNew 2 3 False
+    table   <- Gtk.tableNew 2 4 False
     tvbox   <- Gtk.vBoxNew False 10
     optvbox <- Gtk.vBoxNew False 10
     pcombo  <- Gtk.comboBoxNew
@@ -270,12 +275,15 @@ makeGUI = do
     Gtk.containerAdd nalign nlabel
     Gtk.containerAdd talign tlabel
     Gtk.containerAdd valign vlabel
+    Gtk.containerAdd idxalign idxlabel
     Gtk.tableAttachDefaults table nalign 0 1 0 1
     Gtk.tableAttachDefaults table pentry 1 2 0 1
     Gtk.tableAttachDefaults table talign 0 1 1 2
     Gtk.tableAttachDefaults table pcombo 1 2 1 2
     Gtk.tableAttachDefaults table valign 0 1 2 3
     Gtk.tableAttachDefaults table ventry 1 2 2 3
+    Gtk.tableAttachDefaults table idxalign 0 1 3 4
+    Gtk.tableAttachDefaults table idxspin 1 2 3 4
     Gtk.tableSetRowSpacings table 10
     Gtk.tableSetColSpacings table 10
     let types = ["text", "checkbox", "radio", "textcell"]
@@ -292,8 +300,12 @@ makeGUI = do
     Gtk.containerAdd vleft tvbox
     Gtk.widgetSetChildVisible valign False
     Gtk.widgetSetChildVisible ventry False
+    Gtk.widgetSetChildVisible idxalign False
+    Gtk.widgetSetChildVisible idxspin False
     Gtk.widgetHideAll valign
     Gtk.widgetHideAll ventry
+    Gtk.widgetHideAll idxalign
+    Gtk.widgetHideAll idxspin
 
     -- Window configuration
     Gtk.set win [ Gtk.windowTitle          Gtk.:= msgStr MsgMainTitle
@@ -342,6 +354,8 @@ makeGUI = do
                 , guiModeToolbar = mtoolbar
                 , guiTranslate = msgStr
                 , guiDokButton = akb
+                , guiIndexAlign = idxalign
+                , guiIndexSpin = idxspin
                 }
 
 --------------------------------------------------------------------------------

--- a/Dhek/Property.hs
+++ b/Dhek/Property.hs
@@ -2,28 +2,30 @@ module Dhek.Property where
 
 import Prelude hiding (any)
 
-import Control.Applicative ((<*>), (<$>), (<|>))
-import Control.Lens ((^.), (.~), (&))
-import Control.Monad (when)
+import Control.Applicative ((<*>), (<$>))
+import Control.Lens ((.~), (&))
 
-import Data.Foldable (any, traverse_)
+import Data.Foldable (traverse_)
 
 import Dhek.Free
+import Dhek.GUI
+import Dhek.GUI.Action
 import Dhek.Instr
 import Dhek.Types
 
-onProp :: DhekProgram ()
-onProp = compile $ do
+onProp :: GUI -> DhekProgram ()
+onProp gui = compile $ do
     sOpt <- getSelected
     nOpt <- getEntryText PropEntry
     vOpt <- getEntryText ValueEntry
+    iOpt <- performIO $ gtkGetIndexPropValue gui
     tOpt <- getComboText PropCombo
-    traverse_ (go vOpt) ((,,) <$> sOpt <*> nOpt <*> tOpt)
+    traverse_ (go vOpt iOpt) ((,,) <$> sOpt <*> nOpt <*> tOpt)
   where
-    go v (r,n,t) = do
-        rs <- getRectangles
+    go v idx (r,n,t) = do
         let r1  = r & rectName  .~ n
                     & rectType  .~ t
                     & rectValue .~ v
+                    & rectIndex .~ idx
         setSelected (Just r1)
         addEvent UpdateRectProps

--- a/Dhek/Signal.hs
+++ b/Dhek/Signal.hs
@@ -74,7 +74,8 @@ connectSignals g i = do
     --- Plus Button ---
     Gtk.on (guiZoomInButton g) Gtk.buttonActivated $ void $ runProgram i onPlus
     Gtk.on (guiRemoveButton g) Gtk.buttonActivated $ void $ runProgram i onRem
-    Gtk.on (guiApplyButton g) Gtk.buttonActivated $ void $ runProgram i onProp
+    _ <- Gtk.on (guiApplyButton g) Gtk.buttonActivated $
+        void $ runProgram i (onProp g)
 
     --- Selection ---
     Gtk.on (guiRectTreeSelection g) Gtk.treeSelectionSelectionChanged $ do
@@ -159,13 +160,11 @@ connectSignals g i = do
                 newValue = min (upper - pageSize) (max 0 (oldValue + delta))
             Gtk.adjustmentSetValue (guiVRulerAdjustment g) newValue
 
-    Gtk.on (guiTypeCombo g) Gtk.changed $ do
-        void $ runProgram i $ compile $ do
-            opt <- getComboText PropCombo
-            for_ opt $ \c ->
-                if c == "radio"
-                then setValuePropVisible True
-                else setValuePropVisible False
+    _ <- Gtk.on (guiTypeCombo g) Gtk.changed $ do
+        opt <- Gtk.comboBoxGetActiveText $ guiTypeCombo g
+        for_ opt $ \c -> do
+            gtkSetValuePropVisible (c == "radio") g
+            gtkSetIndexPropVisible (c == "textcell") g
 
     Gtk.on (guiVRuler g) Gtk.buttonPressEvent $ Gtk.tryEvent $ liftIO $
         void $ runProgram i $ compile $ newGuide GuideVertical

--- a/Dhek/Types.hs
+++ b/Dhek/Types.hs
@@ -60,6 +60,7 @@ data Rect = Rect { _rectId     :: {-# UNPACK #-} !Int
                  , _rectName   :: !String
                  , _rectType   :: !String
                  , _rectValue  :: !(Maybe String)
+                 , _rectIndex  :: !(Maybe Int)
                  } deriving (Eq, Show)
 
 data GuideType = GuideVertical | GuideHorizontal
@@ -118,9 +119,13 @@ instance FromJSON Save where
 
 instance ToJSON Rect where
     toJSON r =
-        object $ maybe props (const $ vProp:props) (_rectValue r)
+        object $
+        let ps  = maybe props (const $ vProp:props) (_rectValue r)
+            ps' = maybe ps (const $ iProp:ps) (_rectIndex r) in
+        ps'
       where
         vProp = "value" .= _rectValue r
+        iProp = "index" .= _rectIndex r
 
         props = [ "x"      .= _rectX r
                 , "y"      .= _rectY r
@@ -139,7 +144,8 @@ instance FromJSON Rect where
         v .:  "width"  <*>
         v .:  "name"   <*>
         v .:  "type"   <*>
-        v .:? "value"
+        v .:? "value"  <*>
+        v .:? "index"
     parseJSON _ = mzero
 
 saveNew :: [(Int, Maybe [Rect])] -> Save
@@ -164,7 +170,7 @@ bool True x _  = x
 bool False _ y = y
 
 rectNew :: Double -> Double -> Double -> Double -> Rect
-rectNew x y h w = Rect 0 x y h w "field" "text" Nothing
+rectNew x y h w = Rect 0 x y h w "field" "text" Nothing Nothing
 
 translateRect :: Double -> Double -> Rect -> Rect
 translateRect x y r = r & rectX +~ x & rectY +~ y

--- a/messages/en.msg
+++ b/messages/en.msg
@@ -22,3 +22,4 @@ Value: Value
 Yes: Yes
 No: No
 Confirm: Model has been modified. Do you want to quit anyway ?
+Index: Index

--- a/messages/fr.msg
+++ b/messages/fr.msg
@@ -22,3 +22,4 @@ Value: Valeur
 Yes: Oui
 No: Non
 Confirm: Le modèle a été modifié. Voulez vous quitter sans sauvegarder ces modifications ?
+Index: Index


### PR DESCRIPTION
To distinguish each textcell grouped by same name, we need to add an `index` property (integer >= 0).
