### PR TITLE
DHEK30 - Textcell serialisation

### DIFF
--- a/Dhek/File.hs
+++ b/Dhek/File.hs
@@ -28,7 +28,6 @@ onJsonSave = compile $ do
     traverse_ go fOpt
   where
     go path = do
-        nb <- getPageCount
         rs <- getAllRects
         let nb   = length rs
             save = saveNew $ fillUp nb rs
@@ -63,6 +62,5 @@ exception (e :: SomeException) = showError $ show e
 
 --------------------------------------------------------------------------------
 saveToRects :: Save -> [(Int, [Rect])]
-saveToRects (Save _ xs) = fmap go xs
-  where
-    go (i, xsOpt) = (i, maybe [] id xsOpt)
+saveToRects (Save _ xs)
+    = fmap (\(i, rs) -> (i, expandGrouped rs)) xs


### PR DESCRIPTION
In JSON, for each page group textcell by name:

``` json
{"type":"celltext","name":"field","cells":[{"x":0,"y":0,"width":1,"height":1,"index":0}, ...]}
```

Array "cells" is sorted by "index" in ascending order.
