### PR TITLE
DHEK33 - Auto-increment index property when duplicating textcell

### DIFF
--- a/Dhek/Mode/Duplicate.hs
+++ b/Dhek/Mode/Duplicate.hs
@@ -73,18 +73,17 @@ instance ModeMonad DuplicateMode where
                 liftIO $ gtkSetCursor (Just Gtk.Cross) gui
             Just (Hold x _) -> do
                 rid <- engineDrawState.drawFreshId <+= 1
-                let r = normalize x & rectId .~ rid
+                let r = normalize x & rectId    .~ rid
+                                    & rectIndex %~ (fmap (+1))
 
                 -- Add rectangle
-                pid <- use engineCurPage
                 gui <- ask
-                engineBoards.boardsMap.at pid.traverse.boardRects.at rid ?= r
+                engineStateSetRect r
                 liftIO $ gtkAddRect r gui
 
                 engineDrawState.drawEvent     .= Nothing
                 engineDrawState.drawCollision .= Nothing
 
-                gui <- ask
                 liftIO $ gtkSetCursor Nothing gui
                 engineEventStack %= (CreateRect:)
 


### PR DESCRIPTION
If duplicated textcell have name `n` and index `i` as properties, then duplication can create new textcell keeping `n` as name but with `i + 1` as index (not checking whether user as already manually created other cell with `(name,index) == (n,i+1)`).
