### PR TITLE
Mode help

### DIFF
--- a/Dhek/GUI.hs
+++ b/Dhek/GUI.hs
@@ -384,6 +384,7 @@ makeGUI = do
     sbalign <- Gtk.alignmentNew 0 1 1 0
     ctxId   <- Gtk.statusbarGetContextId sbar "mode"
     Gtk.statusbarSetHasResizeGrip sbar False
+    Gtk.statusbarPush sbar ctxId $ msgStr MsgModeHelp
     Gtk.containerAdd sbalign sbar
     Gtk.boxPackEnd vbox sbalign Gtk.PackNatural 0
 

--- a/Dhek/Signal.hs
+++ b/Dhek/Signal.hs
@@ -133,6 +133,8 @@ connectSignals g i = do
                    Gtk.widgetShowAll $ guiDrawPopup g
                 else
                 do Gtk.statusbarPop (guiStatusBar g) (guiContextId g)
+                   Gtk.statusbarPush (guiStatusBar g) (guiContextId g)
+                       (guiTranslate g $ MsgModeHelp)
                    Gtk.widgetHide $ guiDrawPopup g
             opt <- engineRatio i
             for_ opt $ \r -> do
@@ -146,6 +148,8 @@ connectSignals g i = do
     Gtk.on (guiDrawingArea g) Gtk.leaveNotifyEvent $ Gtk.tryEvent $ liftIO $
         do Gtk.set (guiDrawingArea g) [Gtk.widgetHasFocus Gtk.:= False] -- noop ?
            Gtk.statusbarPop (guiStatusBar g) (guiContextId g)
+           Gtk.statusbarPush (guiStatusBar g) (guiContextId g)
+               (guiTranslate g $ MsgModeHelp)
            Gtk.widgetHide (guiDrawPopup g)
 
     Gtk.on (guiDrawingArea g) Gtk.buttonPressEvent $ Gtk.tryEvent $ do

--- a/messages/en.msg
+++ b/messages/en.msg
@@ -30,3 +30,4 @@ SplashCopy: 4. Copy PDF by filling data according template
 DontSave: Don't save
 DuplicationModePopup: Drag &amp; drop to duplicate
 DuplicationModeStatus: CTRL: Duplication mode. Drag & drop existing area to duplicate it where wanted.
+ModeHelp: Click to draw, CTRL + drag&drop to duplicate

--- a/messages/fr.msg
+++ b/messages/fr.msg
@@ -30,3 +30,4 @@ SplashCopy: 4. Copier le PDF par remplissage selon le modèle
 DontSave: Ne pas enregister
 DuplicationModePopup: Glissé-déposé pour dupliquer
 DuplicationModeStatus: CTRL: Mode duplication. Fait un glissé-déposé d'une zone existante pour la dupliquer à l'endroit souhaité
+ModeHelp: Cliquer pour dessiner, CTRL + glissé-déposé pour dupliquer


### PR DESCRIPTION
When opening initially draw mode (or switching back to after using another mode), it would be nice to display a default help message in status bar.

French:

> Cliquer pour dessiner, CTRL + glissé-dépossé pour dupliquer.

English:

> Click to draw, CTRL + drag&drop to duplicate.
