### PR TITLE
Normalized last index of text cell with auto-generation

### DIFF
--- a/Dhek/Mode/Selection.hs
+++ b/Dhek/Mode/Selection.hs
@@ -226,12 +226,12 @@ distCreateButtonActivated gui
              name = r0 ^. rectName
              s -- Horizontal space between 0 & 1
                  = r1 ^. rectX - (r0 ^. rectX + w)
-             d -- Distance between 0 & N
+             d -- Distance between left of 1 & right of N
                  = rn ^. rectX - (r1 ^. rectX + w + s)
              m -- Number of cells to be created between cell 1 & N
                  = floor (((realToFrac d) / realToFrac (w + s) :: Double))
              rn' -- N index is updated according to 'm' new rectangles
-                 = rn & rectIndex ?~ m+1
+                 = rn & rectIndex ?~ m+2 -- 'm' rect after 2nd rect(1) + 1
 
              -- Create 'm' new rectangles
              loop _ _ []


### PR DESCRIPTION
When using auto-generation tool (from multi-selection mode) on text-cell (to generate cells to fill a span), the last cell (positionned by user) must have its index normalized to index_of_last_generated_cell+1.
