### PR TITLE
Increase selection

### DIFF
--- a/Dhek/Engine/Type.hs
+++ b/Dhek/Engine/Type.hs
@@ -28,7 +28,7 @@ import Dhek.Types
 class (Monad m, Applicative m) => ModeMonad m where
     mMove    :: DrawEnv -> m ()
     mPress   :: DrawEnv -> m ()
-    mRelease :: m ()
+    mRelease :: DrawEnv -> m ()
     mDrawing :: PageItem -> Ratio -> m ()
 
 --------------------------------------------------------------------------------
@@ -187,8 +187,8 @@ press :: DrawEnv -> M ()
 press e = M $ mPress e
 
 --------------------------------------------------------------------------------
-release :: M ()
-release = M mRelease
+release :: DrawEnv -> M ()
+release e = M $ mRelease e
 
 drawing :: PageItem -> Ratio -> M ()
 drawing p r = M $ mDrawing p r

--- a/Dhek/GUI/Action.hs
+++ b/Dhek/GUI/Action.hs
@@ -26,6 +26,7 @@ module Dhek.GUI.Action
     , gtkShowConfirm
     , gtkSetIndexPropVisible
     , gtkGetIndexPropValue
+    , gtkClearSelection
     ) where
 
 --------------------------------------------------------------------------------
@@ -259,6 +260,9 @@ gtkGetIndexPropValue gui = do
             then Just idxvalue
             else Nothing
 
+--------------------------------------------------------------------------------
+gtkClearSelection :: GUI -> IO ()
+gtkClearSelection gui = Gtk.treeSelectionUnselectAll $ guiRectTreeSelection gui
 
 --------------------------------------------------------------------------------
 -- | Utilities

--- a/Dhek/Mode/Common/Draw.hs
+++ b/Dhek/Mode/Common/Draw.hs
@@ -83,6 +83,7 @@ drawRect fw fh (RGB red green blue) s r = do
         h = r ^. rectHeight
         w = r ^. rectWidth
 
+    Cairo.save
     Cairo.setSourceRGB red green blue
     case s of
         Line -> Cairo.setLineWidth 1
@@ -90,6 +91,7 @@ drawRect fw fh (RGB red green blue) s r = do
     Cairo.rectangle x y w h
     Cairo.closePath
     Cairo.stroke
+    Cairo.restore
 
 --------------------------------------------------------------------------------
 drawGuide :: Double -- Width

--- a/Dhek/Mode/Duplicate.hs
+++ b/Dhek/Mode/Duplicate.hs
@@ -71,7 +71,7 @@ instance ModeMonad DuplicateMode where
             Nothing         -> dupStart opts
             Just (Hold x _) -> dupEnd x
 
-    mRelease = return ()
+    mRelease _ = return ()
 
     mDrawing page ratio = do
         gui <- ask

--- a/Dhek/Mode/DuplicateCtrl.hs
+++ b/Dhek/Mode/DuplicateCtrl.hs
@@ -39,7 +39,7 @@ instance ModeMonad DuplicateCtrlMode where
     mPress opts
         = DuplicateCtrlMode $ dupStart opts
 
-    mRelease
+    mRelease _
         = DuplicateCtrlMode $
               do eOpt <- use $ engineDrawState.drawEvent
                  case eOpt of

--- a/Dhek/Mode/Normal.hs
+++ b/Dhek/Mode/Normal.hs
@@ -184,7 +184,7 @@ instance ModeMonad NormalMode where
         --      - click on a rectangle: we enter in event mode (Resize or Hold).
         maybe noEvent onEvent oOpt
 
-    mRelease = do
+    mRelease _ = do
         sOpt <- use $ engineDrawState.drawSelection
         eOpt <- use $ engineDrawState.drawEvent
         gOpt <- use $ engineDrawState.drawCurGuide

--- a/Dhek/Signal.hs
+++ b/Dhek/Signal.hs
@@ -169,7 +169,7 @@ connectSignals g i = do
     Gtk.on (guiDrawingArea g) Gtk.buttonReleaseEvent $ Gtk.tryEvent $ do
         pos <- Gtk.eventCoordinates
         mod <- Gtk.eventModifier
-        liftIO $ drawInterpret mod (const release) i pos
+        liftIO $ drawInterpret mod release i pos
 
     Gtk.on (guiDrawingArea g) Gtk.scrollEvent $ Gtk.tryEvent $ do
         dir <- Gtk.eventScrollDirection


### PR DESCRIPTION
In selection mode, when at least one area is already selected if drawing a new selection (dashed green rect) while META (Ctrl or Cmd) modifier is pressed, then do no replace existing selection by new one, but add new selection to existing one (areas from first and second selections are both selected, part of merged selection).

If there is no previous selection, modifier can be ignored.

**Start event** is either:
- `mousedown`, if META is already pressed (before starting to draw selection).
- `keypressed` with META, if has previously received `mousedown` (start drawing selection) and `mouseup` hasn't been yet fired (to stop drawing selection).

It means that user can press & release META modifier several time until `mouseup`, each time we choose switch between plain selection tool (which will be indicated visually by #173) and update selection tool (which will be indicated visually by #174 ).
