### PR TITLE
Help message in statusbar

### DIFF
--- a/Dhek/Engine.hs
+++ b/Dhek/Engine.hs
@@ -22,9 +22,6 @@ module Dhek.Engine
     , engineModeKeyRelease
     , engineSetMode
     , engineHasEvents
-    , engineIsNormalMode
-    , engineRevertMode
-    , engineIsDuplicateCtrlMode
       -- Draw lenses
     , drawCollision
     , drawCursor

--- a/Dhek/Engine/Runtime.hs
+++ b/Dhek/Engine/Runtime.hs
@@ -38,7 +38,6 @@ import Dhek.Engine.Type
 import Dhek.GUI
 import Dhek.GUI.Action
 import Dhek.Mode.Duplicate
-import Dhek.Mode.DuplicateCtrl
 import Dhek.Mode.Normal
 import Dhek.Mode.Selection
 import Dhek.Types
@@ -68,7 +67,6 @@ data Modes
       { modeDraw            :: IO ModeManager
       , modeDuplication     :: IO ModeManager
       , modeSelection       :: IO ModeManager
-      , modeDuplicationCtrl :: IO ModeManager
       }
 
 --------------------------------------------------------------------------------
@@ -395,32 +393,6 @@ engineSetMode m i = do
         DhekNormal          -> modeDraw
         DhekDuplication     -> modeDuplication
         DhekSelection       -> modeSelection
-        DhekDuplicationCtrl -> modeDuplicationCtrl
-
---------------------------------------------------------------------------------
--- | Reverts to the last mode if exists
-engineRevertMode :: RuntimeEnv -> IO ()
-engineRevertMode i
-    = do mi <- readIORef $ _modeInfo i
-         case _modeInfoPrev mi of
-             Nothing   -> return ()
-             Just prev -> engineSetMode prev i
-
---------------------------------------------------------------------------------
-engineIsNormalMode :: RuntimeEnv -> IO Bool
-engineIsNormalMode i
-    = do mi <- readIORef $ _modeInfo i
-         case _modeInfoCur mi of
-             DhekNormal -> return True
-             _          -> return False
-
---------------------------------------------------------------------------------
-engineIsDuplicateCtrlMode :: RuntimeEnv -> IO Bool
-engineIsDuplicateCtrlMode i
-    = do mi <- readIORef $ _modeInfo i
-         case _modeInfoCur mi of
-             DhekDuplicationCtrl -> return True
-             _                   -> return False
 
 --------------------------------------------------------------------------------
 -- | Returns the current page ratio. Returns Nothing if no PDF has been loaded
@@ -453,12 +425,10 @@ makeRuntimeEnv gui = do
     let mgrNormal        = normalModeManager gui
         mgrDuplication   = duplicateModeManager gui
         mgrSelection     = selectionModeManager (_withContext sRef) gui
-        mgrDuplicateCtrl = duplicateCtrlModeManager gui
         modes = Modes
                 { modeDraw            = mgrNormal
                 , modeDuplication     = mgrDuplication
                 , modeSelection       = mgrSelection
-                , modeDuplicationCtrl = mgrDuplicateCtrl
                 }
 
     curMgr <- mgrNormal

--- a/Dhek/Engine/Type.hs
+++ b/Dhek/Engine/Type.hs
@@ -45,7 +45,6 @@ type Zoom  = Double
 data DhekMode
     = DhekNormal
     | DhekDuplication
-    | DhekDuplicationCtrl
     | DhekSelection
 
 --------------------------------------------------------------------------------

--- a/Dhek/GUI.hs
+++ b/Dhek/GUI.hs
@@ -76,6 +76,7 @@ data GUI =
     , guiStatusBar :: Gtk.Statusbar
     , guiContextId :: Gtk.ContextId
     , guiDrawPopup :: Gtk.Window
+    , guiCursorPixbuf :: IORef (Maybe Gtk.Pixbuf)
     }
 
 --------------------------------------------------------------------------------
@@ -387,7 +388,6 @@ makeGUI = do
     sbalign <- Gtk.alignmentNew 0 1 1 0
     ctxId   <- Gtk.statusbarGetContextId sbar "mode"
     Gtk.statusbarSetHasResizeGrip sbar False
-    Gtk.statusbarPush sbar ctxId $ msgStr MsgModeHelp
     Gtk.containerAdd sbalign sbar
     Gtk.boxPackEnd vbox sbalign Gtk.PackNatural 0
 
@@ -397,7 +397,8 @@ makeGUI = do
 
     Gtk.widgetShowAll win
 
-    cache <- newIORef Nothing
+    cache  <- newIORef Nothing
+    curPix <- newIORef Nothing
 
     return $ GUI{ guiWindow = win
                 , guiPdfDialog = pdfch
@@ -442,6 +443,7 @@ makeGUI = do
                 , guiContextId = ctxId
                 , guiStatusBar = sbar
                 , guiDrawPopup = drawpop
+                , guiCursorPixbuf = curPix
                 }
 
 --------------------------------------------------------------------------------

--- a/Dhek/GUI/Action.hs
+++ b/Dhek/GUI/Action.hs
@@ -34,6 +34,7 @@ module Dhek.GUI.Action
 --------------------------------------------------------------------------------
 import Data.Char (isSpace)
 import Data.Foldable (for_, traverse_)
+import Data.IORef
 import Data.List (dropWhileEnd)
 import Data.Maybe (fromMaybe)
 import Data.Traversable (for, traverse, sequenceA)
@@ -133,6 +134,7 @@ gtkSetGtkCursor gui t = do
     c     <- Gtk.cursorNew t
     frame <- Gtk.widgetGetDrawWindow $ guiDrawingArea gui
     Gtk.drawWindowSetCursor frame (Just c)
+    writeIORef (guiCursorPixbuf gui) Nothing
 
 --------------------------------------------------------------------------------
 dhekCursorImage :: DhekCursorType -> Ptr Gtk.InlineImage
@@ -147,6 +149,7 @@ gtkSetImageCursor gui img
                 cur   <- Gtk.cursorNewFromPixbuf display pix 1 1
                 frame <- Gtk.widgetGetDrawWindow $ guiDrawingArea gui
                 Gtk.drawWindowSetCursor frame (Just cur)
+                writeIORef (guiCursorPixbuf gui) $ Just pix
 
 --------------------------------------------------------------------------------
 gtkIncrPage :: Int -> Int -> [Rect] -> GUI -> IO ()

--- a/Dhek/Mode/Duplicate.hs
+++ b/Dhek/Mode/Duplicate.hs
@@ -32,6 +32,7 @@ import Dhek.Engine.Type
 import Dhek.Geometry
 import Dhek.GUI
 import Dhek.GUI.Action
+import Dhek.I18N
 import Dhek.Mode.Common.Draw
 import Dhek.Types
 
@@ -164,4 +165,9 @@ duplicateMode gui = Mode (runDuplicate gui . runM)
 --------------------------------------------------------------------------------
 duplicateModeManager :: GUI -> IO ModeManager
 duplicateModeManager gui
-    = return $ ModeManager (duplicateMode gui) (return ())
+    = do -- Display duplicate Help message
+         Gtk.statusbarPop (guiStatusBar gui) (guiContextId gui)
+         Gtk.statusbarPush (guiStatusBar gui) (guiContextId gui)
+             (guiTranslate gui MsgDupHelp)
+
+         return $ ModeManager (duplicateMode gui) (return ())

--- a/Dhek/Mode/Normal.hs
+++ b/Dhek/Mode/Normal.hs
@@ -32,7 +32,7 @@ import Dhek.GUI
 import Dhek.GUI.Action
 import Dhek.I18N
 import Dhek.Mode.Common.Draw
-import Dhek.Mode.DuplicateCtrl
+import Dhek.Mode.DuplicateKey
 import Dhek.Types
 import Dhek.Utils (findDelete)
 
@@ -80,7 +80,7 @@ instance ModeMonad NormalMode where
                           do Gtk.statusbarPush (guiStatusBar g) (guiContextId g)
                                  (guiTranslate g $ MsgDuplicationModeStatus)
                              Gtk.widgetShowAll $ guiDrawPopup g
-                             mgr <- duplicateCtrlModeManager g
+                             mgr <- duplicateKeyModeManager g
                              writeIORef ref $ Just mgr
 
     mKeyRelease kb
@@ -378,8 +378,7 @@ normalDrawing page ratio
 --------------------------------------------------------------------------------
 runNormal :: Input -> NormalMode a -> EngineState -> IO EngineState
 runNormal input (NormalMode m) s
-    = do ref     <- newIORef Nothing
-         (s', _) <- execRWST m input s
+    = do (s', _) <- execRWST m input s
          return s'
 
 --------------------------------------------------------------------------------
@@ -390,6 +389,12 @@ normalMode gui = Mode (runNormal gui . runM)
 normalModeManager :: GUI -> IO ModeManager
 normalModeManager gui
     = do ref <- newIORef Nothing
+
+         -- Display normal Help message
+         Gtk.statusbarPop (guiStatusBar gui) (guiContextId gui)
+         Gtk.statusbarPush (guiStatusBar gui) (guiContextId gui)
+             (guiTranslate gui MsgDrawHelp)
+
          let input = Input
                      { inputGUI        = gui
                      , inputCurModeMgr = ref

--- a/Dhek/Mode/Selection.hs
+++ b/Dhek/Mode/Selection.hs
@@ -34,6 +34,7 @@ import           Dhek.Engine.Type
 import           Dhek.Geometry
 import           Dhek.GUI
 import           Dhek.GUI.Action
+import           Dhek.I18N
 import           Dhek.Mode.Common.Draw
 import qualified Dhek.Resources as Resources
 import           Dhek.Types
@@ -527,6 +528,11 @@ selectionModeManager handler gui = do
                 , inputVCenter    = bvcenter
                 }
 
+    -- Display selection Help message
+    Gtk.statusbarPop (guiStatusBar gui) (guiContextId gui)
+    Gtk.statusbarPush (guiStatusBar gui) (guiContextId gui)
+        (guiTranslate gui $ MsgSelectionHelp metaKey)
+
     return $ ModeManager (selectionMode input) $
         liftIO $ do Gtk.signalDisconnect cid
                     Gtk.signalDisconnect did
@@ -558,6 +564,10 @@ createToolbarButton gui img
          Gtk.widgetShowAll b
          Gtk.widgetSetSensitive b False
          return b
+
+--------------------------------------------------------------------------------
+metaKey :: String
+metaKey = "CTRL"
 
 --------------------------------------------------------------------------------
 -- | Utilities

--- a/Dhek/Signal.hs
+++ b/Dhek/Signal.hs
@@ -143,13 +143,6 @@ connectSignals g i = do
     Gtk.on (guiDrawingArea g) Gtk.enterNotifyEvent $ Gtk.tryEvent $ liftIO $
         Gtk.widgetGrabFocus $ guiDrawingArea g
 
-    Gtk.on (guiDrawingArea g) Gtk.leaveNotifyEvent $ Gtk.tryEvent $ liftIO $
-        do Gtk.set (guiDrawingArea g) [Gtk.widgetHasFocus Gtk.:= False] -- noop ?
-           Gtk.statusbarPop (guiStatusBar g) (guiContextId g)
-           Gtk.statusbarPush (guiStatusBar g) (guiContextId g)
-               (guiTranslate g $ MsgModeHelp)
-           Gtk.widgetHide (guiDrawPopup g)
-
     Gtk.on (guiDrawingArea g) Gtk.buttonPressEvent $ Gtk.tryEvent $ do
        pos <- Gtk.eventCoordinates
        b   <- Gtk.eventButton

--- a/dhek.cabal
+++ b/dhek.cabal
@@ -64,7 +64,7 @@ executable dhek
                  Dhek.I18N
                  Dhek.Mode.Common.Draw
                  Dhek.Mode.Duplicate
-                 Dhek.Mode.DuplicateCtrl
+                 Dhek.Mode.DuplicateKey
                  Dhek.Mode.Normal
                  Dhek.Mode.Selection
                  Dhek.Property

--- a/messages/en.msg
+++ b/messages/en.msg
@@ -30,4 +30,6 @@ SplashCopy: 4. Copy PDF by filling data according template
 DontSave: Don't save
 DuplicationModePopup: Drag &amp; drop to duplicate
 DuplicationModeStatus: ALT: Duplication mode. Drag & drop existing area to duplicate it where wanted.
-ModeHelp: Click to draw, ALT + drag&drop to duplicate
+DrawHelp: Click to draw, ALT + drag&drop to duplicate
+DupHelp: Drag&drop area to duplicate it
+SelectionHelp meta@String: Click to start selection, release to finalize. #{meta} + click to update selection.

--- a/messages/fr.msg
+++ b/messages/fr.msg
@@ -30,4 +30,6 @@ SplashCopy: 4. Copier le PDF par remplissage selon le modèle
 DontSave: Ne pas enregister
 DuplicationModePopup: Glissé-déposé pour dupliquer
 DuplicationModeStatus: ALT: Mode duplication. Fait un glissé-déposé d'une zone existante pour la dupliquer à l'endroit souhaité
-ModeHelp: Cliquer pour dessiner, ALT + glissé-déposé pour dupliquer
+DrawHelp: Cliquer pour dessiner, ALT + glissé-déposé pour dupliquer
+DupHelp: Glissé-déposé une zone pour la dupliquer
+SelectionHelp meta@String: Cliquer pour débuter une sélection, relâcher pour terminer. #{meta} + clic pour modifier la sélection.


### PR DESCRIPTION
Help message is not updated when mode changes.
- Currently: Always keep Draw mode message ("Cliquer pour dessiner, ..."), even in Duplication or Selection mode.
- Expected: Message specific to mode set each time mode is activated. Means no change at app launch as Draw mode is the one activated when it starts, but should not be the same when other mode is activated.

**For Duplication Mode:**
_French_

> Glisser-déposer une zone pour la dupliquer.

_English_

> Drag&drop area to duplicate it.

**For Selection Mode:**
_French_

> Cliquer pour débuter une sélection, relâcher pour terminer. META + clic pour modifier la sélection.

_English_

> Click to start selection, release to finalize. META + click to update selection.

(META = to be replaced CTRL by default, and by CMD on Mac OS X)
