### PR TITLE
Display duplication cursor earlier

### DIFF
--- a/Dhek/Engine.hs
+++ b/Dhek/Engine.hs
@@ -20,6 +20,8 @@ module Dhek.Engine
     , engineModeDraw
     , engineModeKeyPress
     , engineModeKeyRelease
+    , engineModeEnter
+    , engineModeLeave
     , engineSetMode
     , engineHasEvents
       -- Draw lenses

--- a/Dhek/Engine/Type.hs
+++ b/Dhek/Engine/Type.hs
@@ -32,6 +32,8 @@ class (Monad m, Applicative m) => ModeMonad m where
     mDrawing    :: PageItem -> Ratio -> m ()
     mKeyPress   :: KbEnv -> m ()
     mKeyRelease :: KbEnv -> m ()
+    mEnter      :: m ()
+    mLeave      :: m ()
 
 --------------------------------------------------------------------------------
 -- | Declarations
@@ -175,6 +177,8 @@ instance ModeMonad M where
     mDrawing    = drawing
     mKeyPress   = keyPress
     mKeyRelease = keyRelease
+    mEnter      = enter
+    mLeave      = leave
 
 --------------------------------------------------------------------------------
 -- | Mode Run
@@ -211,6 +215,14 @@ keyPress e = M $ mKeyPress e
 --------------------------------------------------------------------------------
 keyRelease :: KbEnv -> M ()
 keyRelease e = M $ mKeyRelease e
+
+--------------------------------------------------------------------------------
+enter :: M ()
+enter = M mEnter
+
+--------------------------------------------------------------------------------
+leave :: M ()
+leave = M mLeave
 
 --------------------------------------------------------------------------------
 -- | Helpers

--- a/Dhek/Mode/Duplicate.hs
+++ b/Dhek/Mode/Duplicate.hs
@@ -123,6 +123,10 @@ instance ModeMonad DuplicateMode where
 
     mKeyRelease _ = return ()
 
+    mEnter = return ()
+
+    mLeave = return ()
+
 --------------------------------------------------------------------------------
 dupStart :: DrawEnv -> DuplicateMode ()
 dupStart opts

--- a/Dhek/Mode/DuplicateKey.hs
+++ b/Dhek/Mode/DuplicateKey.hs
@@ -58,6 +58,10 @@ instance ModeMonad DuplicateKeyMode where
 
     mKeyRelease _ = return ()
 
+    mEnter = return ()
+
+    mLeave = return ()
+
 --------------------------------------------------------------------------------
 runDuplicateKey :: GUI -> DuplicateKeyMode a -> EngineState -> IO EngineState
 runDuplicateKey gui (DuplicateKeyMode m) s

--- a/Dhek/Mode/Normal.hs
+++ b/Dhek/Mode/Normal.hs
@@ -83,6 +83,7 @@ instance ModeMonad NormalMode where
                                  (guiTranslate g MsgDupHelp)
                              Gtk.widgetShowAll $ guiDrawPopup g
                              updatePopupPos g
+                             gtkSetDhekCursor g (Just $ DhekCursor CursorDup)
 
     mKeyRelease kb
         = do input <- ask
@@ -100,6 +101,31 @@ instance ModeMonad NormalMode where
                                           (guiContextId g)
                                       Gtk.widgetHide $ guiDrawPopup g
                                       writeIORef ref Nothing
+                                      gtkSetDhekCursor g Nothing
+
+    mEnter
+        = do input <- ask
+             let g   = inputGUI input
+                 ref = inputCurModeMgr input
+             opt <- liftIO $ readIORef ref
+             case opt of
+                 Nothing -> return ()
+                 -- In duplication mode
+                 Just _
+                     -> liftIO $
+                            do Gtk.widgetShowAll $ guiDrawPopup g
+                               updatePopupPos g
+
+    mLeave
+        = do input <- ask
+             let g   = inputGUI input
+                 ref = inputCurModeMgr input
+             opt <- liftIO $ readIORef ref
+             case opt of
+                 Nothing -> return ()
+                 -- In duplication mode
+                 Just _
+                     -> liftIO $ Gtk.widgetHide $ guiDrawPopup g
 
 --------------------------------------------------------------------------------
 runOrMode :: NormalMode () -> M () -> NormalMode ()

--- a/Dhek/Mode/Selection.hs
+++ b/Dhek/Mode/Selection.hs
@@ -200,6 +200,10 @@ instance ModeMonad SelectionMode where
 
     mKeyRelease _ = return ()
 
+    mEnter = return ()
+
+    mLeave = return ()
+
 --------------------------------------------------------------------------------
 metaModifierPressed :: [Gtk.Modifier] -> Bool
 metaModifierPressed [Gtk.Control]

--- a/Dhek/Signal.hs
+++ b/Dhek/Signal.hs
@@ -141,7 +141,11 @@ connectSignals g i = do
            liftIO $ engineModeKeyRelease mod name i
 
     Gtk.on (guiDrawingArea g) Gtk.enterNotifyEvent $ Gtk.tryEvent $ liftIO $
-        Gtk.widgetGrabFocus $ guiDrawingArea g
+        do Gtk.widgetGrabFocus $ guiDrawingArea g
+           engineModeEnter i
+
+    Gtk.on (guiDrawingArea g) Gtk.leaveNotifyEvent $ Gtk.tryEvent $ liftIO $
+        engineModeLeave i
 
     Gtk.on (guiDrawingArea g) Gtk.buttonPressEvent $ Gtk.tryEvent $ do
        pos <- Gtk.eventCoordinates


### PR DESCRIPTION
While in Draw mode, update mouse cursor to Duplication one (the one of Duplication mode) as soon as key modifier (ALT) is detected over drawing zone, not waiting mouse to be pressed.

**Summary:**
- _(todo)_ Event for cursor change = pointer over drawing zone (mouse move?) + ALT
- _(todo)_ Event to rollback cursor to default one of Draw mode = ALT release OR mouse exit drawing zone.
- _(already impl'ed)_ Event to start duplication mode = ALT + mouse pressed on drawing zone
