### PR TITLE
Tooltip for Draw mode

### DIFF
--- a/Dhek/GUI.hs
+++ b/Dhek/GUI.hs
@@ -175,6 +175,8 @@ makeGUI = do
     -- Button Draw
     drwb <- Gtk.toggleToolButtonNew
     dimg <- loadImage Resources.drawRectangle
+    Gtk.set drwb [Gtk.widgetTooltipText Gtk.:=
+                  Just $ msgStr MsgNormalModeTooltip]
     Gtk.toolButtonSetIconWidget drwb $ Just dimg
     Gtk.toggleToolButtonSetActive drwb True
 

--- a/messages/en.msg
+++ b/messages/en.msg
@@ -33,3 +33,4 @@ DrawHelp: Click to draw, ALT + drag&drop to duplicate
 DupHelp: Drag&drop area to duplicate it
 SelectionHelp meta@String: Click to start selection, release to finalize. #{meta} + click to update selection.
 JsonFormatError msg@String: Invalid mapping file: #{msg}
+NormalModeTooltip: Draw areas over document

--- a/messages/fr.msg
+++ b/messages/fr.msg
@@ -33,3 +33,4 @@ DrawHelp: Cliquer pour dessiner, ALT + glissé-déposé pour dupliquer
 DupHelp: Glisser-déposer une zone pour la dupliquer
 SelectionHelp meta@String: Cliquer pour débuter une sélection, relâcher pour terminer. #{meta} + clic pour modifier la sélection.
 JsonFormatError msg@String: Format du fichier modèle incorrect: #{msg}
+NormalModeTooltip: Dessiner les zones sur le document


### PR DESCRIPTION
Add tooltip for the button of Draw mode in toolbar.

French:

> Dessiner les zones sur le document.

English:

> Draw areas over document.
