### PR TITLE
Move in selection mode

### DIFF
--- a/dhek.cabal
+++ b/dhek.cabal
@@ -1,5 +1,5 @@
 name:                dhek
-version:             1.0.9
+version:             1.0.10
 -- synopsis:
 -- description:
 -- license:


### PR DESCRIPTION
_In selection mode_ when dragging an area (mouse down on an rect, move, mouse up):
- If area was not previously selected, then ensure the selection is a list with only this area in (discard any different previous selection), and move only the single selected area (like move in Draw mode). After being moved in this way, the involved area remains selected and is the only one selected.
- If area is part of current selection, selection is un changed, clicked area is moved as in Draw mode. If there is other areas in selection, then each is following the moved one : if movement of clicked area is x+10 & y+20, then the same is applied to other selected areas. After move the selection remains the same.
