### PR TITLE
Do not save when there is area

### DIFF
--- a/Dhek/Engine/Instr.hs
+++ b/Dhek/Engine/Instr.hs
@@ -35,6 +35,7 @@ data Event
     | UpdateRectPos
     | DeleteRect
     | UpdateRectProps
+    deriving Show
 
 --------------------------------------------------------------------------------
 newtype Instr a = Instr (forall m. Runtime m => m a)
@@ -71,6 +72,7 @@ class (Applicative m, Monad m, MonadIO m) => Runtime m where
     rIsActive         :: DhekOption -> m Bool
     rAddEvent         :: Event -> m ()
     rClearEvents      :: m ()
+    rShowWarning      :: String -> m ()
 
 --------------------------------------------------------------------------------
 instance Functor Instr where
@@ -124,6 +126,7 @@ instance Runtime Instr where
     rIsActive = isActive
     rAddEvent = addEvent
     rClearEvents = clearEvents
+    rShowWarning = showWarning
 
 --------------------------------------------------------------------------------
 getSelected :: Instr (Maybe Rect)
@@ -244,3 +247,7 @@ addEvent e = Instr $ rAddEvent e
 --------------------------------------------------------------------------------
 clearEvents :: Instr ()
 clearEvents = Instr rClearEvents
+
+--------------------------------------------------------------------------------
+showWarning :: String -> Instr ()
+showWarning s = Instr $ rShowWarning s

--- a/Dhek/File.hs
+++ b/Dhek/File.hs
@@ -61,8 +61,8 @@ onJsonImport gui
                         either reportError upd rectsE
 
     upd rs
-        = do clearEvents
-             setAllRects rs
+        = do setAllRects rs
+             clearEvents
              draw
 
 --------------------------------------------------------------------------------

--- a/Dhek/GUI/Action.hs
+++ b/Dhek/GUI/Action.hs
@@ -29,6 +29,7 @@ module Dhek.GUI.Action
     , gtkSetIndexPropVisible
     , gtkGetIndexPropValue
     , gtkClearSelection
+    , gtkShowWarning
     ) where
 
 --------------------------------------------------------------------------------
@@ -301,6 +302,14 @@ gtkGetIndexPropValue gui = do
 --------------------------------------------------------------------------------
 gtkClearSelection :: GUI -> IO ()
 gtkClearSelection gui = Gtk.treeSelectionUnselectAll $ guiRectTreeSelection gui
+
+--------------------------------------------------------------------------------
+gtkShowWarning :: GUI -> String -> IO ()
+gtkShowWarning gui e = do
+    m <- Gtk.messageDialogNew (Just $ guiWindow gui)
+         [Gtk.DialogModal] Gtk.MessageWarning Gtk.ButtonsOk e
+    Gtk.dialogRun m
+    Gtk.widgetHide m
 
 --------------------------------------------------------------------------------
 -- | Utilities

--- a/Dhek/Signal.hs
+++ b/Dhek/Signal.hs
@@ -58,8 +58,12 @@ connectSignals g i = do
     Gtk.on (guiJsonOpenMenuItem g) Gtk.menuItemActivate $
         void $ runProgram i $ onJsonImport g
 
-    Gtk.on (guiJsonSaveMenuItem g) Gtk.menuItemActivate $
-        void $ runProgram i onJsonSave
+    Gtk.on (guiJsonSaveMenuItem g) Gtk.menuItemActivate $ runProgram i $
+        do rs <- getAllRects
+           let rs' = rs >>= snd
+           if null rs'
+               then showWarning $ guiTranslate g MsgNoArea
+               else void onJsonSave
 
     Gtk.on (guiOverlapMenuItem g) Gtk.menuItemActivate $ void $ runProgram i $
         do b <- isActive Overlap

--- a/messages/en.msg
+++ b/messages/en.msg
@@ -36,3 +36,4 @@ JsonFormatError msg@String: Invalid mapping file: #{msg}
 NormalModeTooltip: Draw areas over document
 OpenBlank: Open blank document
 BlankDocument: *Blank Document*
+NoArea: No area was defined. Template file cannot be saved.

--- a/messages/fr.msg
+++ b/messages/fr.msg
@@ -36,3 +36,4 @@ JsonFormatError msg@String: Format du fichier modèle incorrect: #{msg}
 NormalModeTooltip: Dessiner les zones sur le document
 OpenBlank: Ouvrir un document vierge
 BlankDocument: *Document vierge*
+NoArea: Aucune zone n'a été ajoutée. Le fichier modèle ne peut être sauvegardé.


### PR DESCRIPTION
When user try to save, do not show the Save dialog when there is no area at all.

Instead a warning can be displayed:

_French_

> Aucune zone n'a été ajoutée. Le fichier modèle ne peut être sauvegardé.

_English_

> No area was defined. Template file cannot be saved.
