### PR TITLE
 Key modifier for selection update

### DIFF
--- a/darwin/Dhek/AppUtil.hs
+++ b/darwin/Dhek/AppUtil.hs
@@ -1,27 +1,37 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
-
 --------------------------------------------------------------------------------
 -- |
 -- Module : Dhek.AppUtil
 --
--- This module declares application utilities, 
+-- This module declares application utilities,
 -- related to Darwin/Mac OS X integration.
 --
 --------------------------------------------------------------------------------
 module Dhek.AppUtil where
 
+--------------------------------------------------------------------------------
 import Foreign.C
 import System.Exit (exitSuccess)
 
+--------------------------------------------------------------------------------
 foreign import ccall "util.h nsappTerminate" nsappTerminate :: IO ()
 foreign import ccall "util.h nsbrowserOpen" nsbrowserOpen :: CString -> IO ()
 
+--------------------------------------------------------------------------------
 appTerminate :: IO ()
 appTerminate = do
   exitSuccess -- ???
   nsappTerminate
 
+--------------------------------------------------------------------------------
 browserOpen :: String -> IO ()
 browserOpen url = do
   curl <- newCString url
   nsbrowserOpen curl
+
+--------------------------------------------------------------------------------
+-- | Returns true if given key name is the one of expected modifier
+isKeyModifier :: String -> Bool
+isKeyModifier "Meta_L" = True
+isKeyModifier "Meta_R" = True
+isKeyModifier _        = False

--- a/unix/Dhek/AppUtil.hs
+++ b/unix/Dhek/AppUtil.hs
@@ -8,8 +8,17 @@
 --------------------------------------------------------------------------------
 module Dhek.AppUtil where
 
+--------------------------------------------------------------------------------
 appTerminate :: IO ()
 appTerminate = return ()
 
+--------------------------------------------------------------------------------
 browserOpen :: String -> IO ()
 browserOpen url = return ()
+
+--------------------------------------------------------------------------------
+-- | Returns true if given key name is the one of expected modifier
+isKeyModifier :: String -> Bool
+isKeyModifier "Control_L" = True
+isKeyModifier "Control_R" = True
+isKeyModifier _           = False

--- a/win/dhek/AppUtil.hs
+++ b/win/dhek/AppUtil.hs
@@ -9,17 +9,26 @@
 --------------------------------------------------------------------------------
 module Dhek.AppUtil where
 
+--------------------------------------------------------------------------------
 import Foreign.C
 import Foreign.C.String
 
+--------------------------------------------------------------------------------
 foreign import ccall "util.h browser_open" browser_open :: CString -> IO ()
 
+--------------------------------------------------------------------------------
 appTerminate :: IO ()
 appTerminate = return ()
 
+--------------------------------------------------------------------------------
 browserOpen :: String -> IO ()
 browserOpen url = do
   curl <- newCString url
   browser_open curl
-  
 
+--------------------------------------------------------------------------------
+-- | Returns true if given key name is the one of expected modifier
+isKeyModifier :: String -> Bool
+isKeyModifier "Control_L" = True
+isKeyModifier "Control_R" = True
+isKeyModifier _           = False


### PR DESCRIPTION
In Selection mode, key modifier to inscrease or decrease existing selection should be CTRL by default, but CMD on Mac OS X.
