### PR TITLE
Update selection after deletion

### DIFF
--- a/Dhek/Engine/Misc/LastHistory.hs
+++ b/Dhek/Engine/Misc/LastHistory.hs
@@ -1,0 +1,49 @@
+--------------------------------------------------------------------------------
+-- |
+-- Module : Dhek.Engine.Misc.LastHistory
+--
+--------------------------------------------------------------------------------
+module Dhek.Engine.Misc.LastHistory
+    ( LastHistory
+    , lhNew
+    , lhPush
+    , lhPeek
+    , lhPop
+    ) where
+
+--------------------------------------------------------------------------------
+import Data.Foldable
+import Data.List
+
+--------------------------------------------------------------------------------
+newtype LastHistory k = LastHistory [k]
+
+--------------------------------------------------------------------------------
+instance Foldable LastHistory where
+    foldMap f (LastHistory xs) = foldMap f xs
+
+--------------------------------------------------------------------------------
+lhNew :: LastHistory k
+lhNew = LastHistory []
+
+--------------------------------------------------------------------------------
+lhPush :: Eq k => k -> LastHistory k -> LastHistory k
+lhPush k (LastHistory ks)
+    = LastHistory newKs
+  where
+    newKs = k : delete k ks
+
+--------------------------------------------------------------------------------
+lhPeek :: LastHistory k -> Maybe k
+lhPeek = fst . lhPop'
+
+--------------------------------------------------------------------------------
+lhPop :: LastHistory k -> LastHistory k
+lhPop = snd . lhPop'
+
+--------------------------------------------------------------------------------
+lhPop' :: LastHistory k -> (Maybe k, LastHistory k)
+lhPop' l@(LastHistory xs)
+    = case xs of
+          []     -> (Nothing, l)
+          x:rest -> (Just x, LastHistory rest)

--- a/Dhek/Engine/Type.hs
+++ b/Dhek/Engine/Type.hs
@@ -21,6 +21,7 @@ import           Graphics.UI.Gtk (Modifier)
 --------------------------------------------------------------------------------
 import Dhek.Cartesian
 import Dhek.Engine.Instr
+import Dhek.Engine.Misc.LastHistory
 import Dhek.Types
 
 --------------------------------------------------------------------------------
@@ -89,7 +90,7 @@ data KbEnv
 --------------------------------------------------------------------------------
 data DrawState
     = DrawState
-      { _drawSelected  :: !(Maybe Rect)
+      { _drawSelected  :: !(LastHistory Int) -- hold Rect id
       , _drawOverRect  :: !(Maybe Rect)
       , _drawFreshId   :: !Int
       , _drawNewGuide  :: !(Maybe Guide)
@@ -123,7 +124,7 @@ data EngineEnv
 -- | Constructors
 --------------------------------------------------------------------------------
 drawStateNew :: DrawState
-drawStateNew = DrawState{ _drawSelected  = Nothing
+drawStateNew = DrawState{ _drawSelected  = lhNew
                         , _drawOverRect  = Nothing
                         , _drawFreshId   = 0
                         , _drawNewGuide  = Nothing
@@ -230,6 +231,13 @@ engineStateSetRect r
     = do pid <- use engineCurPage
          let rid = r ^. rectId
          engineBoards.boardsMap.at pid.traverse.boardRects.at rid ?= r
+
+--------------------------------------------------------------------------------
+engineStateGetRect :: MonadState EngineState m => Int -> m (Maybe Rect)
+engineStateGetRect rid
+    = do pid <- use engineCurPage
+         m   <- use $ engineBoards.boardsMap.at pid.traverse.boardRects
+         return $ I.lookup rid m
 
 --------------------------------------------------------------------------------
 engineStateGetGuides :: MonadState EngineState m => m [Guide]

--- a/dhek.cabal
+++ b/dhek.cabal
@@ -62,6 +62,7 @@ executable dhek
                  Dhek.Cartesian
                  Dhek.Engine
                  Dhek.Engine.Instr
+                 Dhek.Engine.Misc.LastHistory
                  Dhek.Engine.Runtime
                  Dhek.Engine.Type
                  Dhek.File


### PR DESCRIPTION
When an area is deleted, if possible keep something selected:
- if there is an area after, select this one,
- otherwise if there an area before select it.

It allows to perform deletion sequence (delete several area one after another).
