### PR TITLE
Selection rendering

### DIFF
--- a/Dhek/Mode/Common/Draw.hs
+++ b/Dhek/Mode/Common/Draw.hs
@@ -16,6 +16,9 @@ import Dhek.Types
 data RGB = RGB Double Double Double
 
 --------------------------------------------------------------------------------
+data RGBA = RGBA Double Double Double Double
+
+--------------------------------------------------------------------------------
 data Style = Line
            | Dash
 
@@ -90,6 +93,35 @@ drawRect (RGB red green blue) s r = do
     Cairo.closePath
     Cairo.stroke
     Cairo.restore
+
+--------------------------------------------------------------------------------
+drawRectA :: RGBA
+          -> RGBA
+          -> Style
+          -> Rect
+          -> Cairo.Render ()
+drawRectA rgbaR rgbaB s r = do
+    let x = r ^. rectX
+        y = r ^. rectY
+        h = r ^. rectHeight
+        w = r ^. rectWidth
+
+    Cairo.save
+    Cairo.setSourceRGBA redB greenB blueB alphaB
+    case s of
+        Line -> Cairo.setLineWidth 1
+        Dash -> Cairo.setDash [5] 5
+    Cairo.rectangle x y w h
+    Cairo.stroke
+    Cairo.setSourceRGBA redR greenR blueR alphaR
+    Cairo.rectangle x y w h
+    Cairo.fill
+    Cairo.closePath
+    Cairo.restore
+
+  where
+    (RGBA redR greenR blueR alphaR) = rgbaR
+    (RGBA redB greenB blueB alphaB) = rgbaB
 
 --------------------------------------------------------------------------------
 drawGuide :: Double -- Width

--- a/Dhek/Mode/Selection.hs
+++ b/Dhek/Mode/Selection.hs
@@ -115,7 +115,9 @@ instance ModeMonad SelectionMode where
                                   (rects \\ rsSel)
 
                     _ -> do let selection = mAct >>= getSelectionRect
-                            traverse_ (drawRect selectionColor Dash) selection
+                            traverse_
+                                (drawRectA selectionRColor selectionBColor Line)
+                                selection
                             traverse_ (drawRect regularColor Line)
                                 (rects \\ rsSel)
                             traverse_ (drawRect selectedColor Line) rsSel
@@ -123,7 +125,8 @@ instance ModeMonad SelectionMode where
       where
         regularColor   = rgbBlue
         selectedColor  = rgbRed
-        selectionColor = rgbGreen
+        selectionRColor = RGBA 0 0 0 0.18
+        selectionBColor = RGBA 0 0 0 0.3
 
     mKeyPress kb
         = when (isKeyModifier $ kbKeyName kb) $


### PR DESCRIPTION
New rendering for selection: a filled rect over area rects.
- Border 1px solid (no longer dashed), black (#000) with opacity 10% (transparency 90%).
- Background (fill color), black (#000) with opacity 18%.

![sel](https://cloud.githubusercontent.com/assets/166062/4233899/3069e1c2-39b1-11e4-9ab1-44ae01a14f84.png)
